### PR TITLE
🔧 Fix warning generated by still using `setuptools`

### DIFF
--- a/chef/acl.py
+++ b/chef/acl.py
@@ -1,4 +1,4 @@
-import pkg_resources
+import packaging.version
 from chef.api import ChefAPI
 from chef.exceptions import ChefObjectTypeError
 from chef.permissions import Permissions
@@ -96,7 +96,7 @@ class Acl(object):
     object_types = ["clients", "containers", "cookbooks", "data", "environments", "groups", "nodes", "roles"]
 
     """ ALC API available only in Chef server from version 12.0"""
-    version = pkg_resources.parse_version("12.0.0")
+    version = packaging.version.parse("12.0.0")
 
     def __init__(self, object_type, name, api, skip_load=False):
         self._check_object_type(object_type)

--- a/chef/api.py
+++ b/chef/api.py
@@ -8,8 +8,7 @@ import threading
 import urllib
 import weakref
 
-import pkg_resources
-
+import packaging.version
 import requests
 
 from chef.auth import sign_request
@@ -68,7 +67,7 @@ class ChefAPI(object):
         self.timeout = timeout
         self.version = version
         self.headers = dict((k.lower(), v) for k, v in headers.items())
-        self.version_parsed = pkg_resources.parse_version(self.version)
+        self.version_parsed = packaging.version.parse(self.version)
         self.platform = self.parsed_url.hostname == 'api.opscode.com'
         self.ssl_verify = ssl_verify
         if not api_stack_value():

--- a/chef/base.py
+++ b/chef/base.py
@@ -1,6 +1,6 @@
 import collections
 
-import pkg_resources
+import packaging.version
 from chef.acl import Acl
 
 from chef.api import ChefAPI
@@ -32,7 +32,7 @@ class ChefObjectMeta(type):
         super(ChefObjectMeta, cls).__init__(name, bases, d)
         if name != 'ChefObject':
             ChefObject.types[name.lower()] = cls
-        cls.api_version_parsed = pkg_resources.parse_version(cls.api_version)
+        cls.api_version_parsed = packaging.version.parse(cls.api_version)
 
 
 class ChefObject(metaclass=ChefObjectMeta):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,16 +46,29 @@ copyright = u'2010-2012, Noah Kantrowitz'
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-import pkg_resources
 try:
-    release = pkg_resources.get_distribution('PyChef').version
-except pkg_resources.DistributionNotFound:
-    print 'To build the documentation, The distribution information of PyChef'
-    print 'Has to be available.  Either install the package into your'
-    print 'development environment or run "setup.py develop" to setup the'
-    print 'metadata.  A virtualenv is recommended!'
-    sys.exit(1)
-del pkg_resources
+    from importlib import metadata
+except ImportError:
+    try:
+        import importlib_metadata as metadata
+    except ImportError:
+        metadata = None
+
+try:
+    if metadata is None:
+        raise ImportError
+    release = metadata.version('PyChef')
+except (ImportError, Exception):
+    try:
+        import pkg_resources
+        release = pkg_resources.get_distribution('PyChef').version
+        del pkg_resources
+    except (ImportError, Exception):
+        print('To build the documentation, The distribution information of PyChef')
+        print('Has to be available.  Either install the package into your')
+        print('development environment or run "setup.py develop" to setup the')
+        print('metadata.  A virtualenv is recommended!')
+        sys.exit(1)
 
 if 'dev' in release:
     release = release.split('dev')[0] + 'dev'

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     zip_safe = False,
     python_requires = '>=3.11',
-    install_requires = ['requests>=2.7.0'],
+    install_requires = ['requests>=2.7.0', 'packaging'],
     tests_require = ['unittest2', 'mock'],
     test_suite = 'unittest2.collector',
 )


### PR DESCRIPTION
Replace it by `packaging`

Here was the warning message:

```
chef/api.py:11: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
```