### PR TITLE
Fix last deprecation warning

### DIFF
--- a/chef/api.py
+++ b/chef/api.py
@@ -193,7 +193,7 @@ class ChefAPI(object):
     def request(self, method, path, headers={}, data=None):
         auth_headers = sign_request(key=self.key, http_method=method,
             path=self.parsed_url.path+path.split('?', 1)[0], body=data,
-            host=self.parsed_url.netloc, timestamp=datetime.datetime.utcnow(),
+            host=self.parsed_url.netloc, timestamp=datetime.datetime.now(datetime.timezone.utc),
             user_id=self.client)
         request_headers = {}
         request_headers.update(self.headers)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name = 'PyChef',
-    version = '0.4.3+criteo',
+    version = '0.4.4+criteo',
     packages = find_packages(),
     author = 'Noah Kantrowitz',
     author_email = 'noah@coderanger.net',


### PR DESCRIPTION
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).